### PR TITLE
Add a notice to PHPUnit saying it'll take a while

### DIFF
--- a/environment/scripts/php-phpunit.sh
+++ b/environment/scripts/php-phpunit.sh
@@ -7,7 +7,7 @@ echo "Adding Pear channels"
 pear channel-discover pear.phpunit.de
 pear channel-discover pear.symfony.com
 
-echo "Installing PHPUnit"
+echo "Installing PHPUnit - note this might take a while"
 pear install phpunit/PHPUnit
 
 echo "PHPUnit and Pear installed"


### PR DESCRIPTION
There is no -v or --verbose option to show a progress bar or similar to avoid people thinking installation is hanging. PHPUnit does take a while to install.
