### PR TITLE
grunt + grunt-watch robustness changes

### DIFF
--- a/environment/scripts/grunt-watch.sh
+++ b/environment/scripts/grunt-watch.sh
@@ -5,7 +5,7 @@ echo "Setting up grunt watch startup script (depends on grunt.sh)"
 if [ -r "/var/www/html/package.json" ]
 then
 	echo "Adding startup script 'grunt-watch.sh' to /etc/init.d";
-	echo "cd /vagrant/www && sudo nohup grunt watch > /dev/null 2> /dev/null < /dev/null &" > /etc/init.d/grunt-watch.sh
+	echo "cd /var/www/html && sudo nohup grunt watch > /dev/null 2> /dev/null < /dev/null &" > /etc/init.d/grunt-watch.sh
 	echo "Running grunt-watch.sh";
 	chmod +x /etc/init.d/grunt-watch.sh
 	/etc/init.d/grunt-watch.sh

--- a/environment/scripts/grunt.sh
+++ b/environment/scripts/grunt.sh
@@ -8,8 +8,8 @@ if [ -r "package.json" ]
 then
 	echo "Installing declared packages from package.json"
 	npm install --save-dev --no-bin-links
-	echo "Running grunt default"
-	grunt default
+	echo "Running grunt default (with --force if this is an empty project)"
+	grunt default --force
 else
 	echo "WARNING: There was no (readable) package.json. Create one and run 'npm install --save-dev --no-bin-links' to install manually."
 fi;


### PR DESCRIPTION
On bootstrap run grunt default --force to stop error messages terminating the bootstrap
grunt-watch install runs from the same working directory so the execution works correctly
