### PR TITLE
XDebug script added as optional addition

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,6 +34,7 @@ Vagrant.configure("2") do |config|
   #config.vm.provision :shell, :path => "environment/scripts/mariadb-5.5.sh"
   #config.vm.provision :shell, :path => "environment/scripts/php-geoip.sh"
   config.vm.provision :shell, :path => "environment/scripts/php-phpunit.sh"
+  #config.vm.provision :shell, :path => "environment/scripts/php-xdebug.sh"
   #config.vm.provision :shell, :path => "environment/scripts/php-apc.sh"
   #config.vm.provision :shell, :path => "environment/scripts/mongo.sh"
   #config.vm.provision :shell, :path => "environment/scripts/php-mongo.sh"

--- a/environment/scripts/php-xdebug.sh
+++ b/environment/scripts/php-xdebug.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo "Installing XDebug dependencies"
+yum install -y php-devel gcc gcc-c++ autoconf automake
+
+echo "Installing XDebug"
+pecl install -y Xdebug
+
+echo "Ensuring XDebug is executable"
+chmod +x /usr/lib64/php/modules/xdebug.so
+
+echo "Appending xdebug configuration details to /etc/php.ini"
+echo "[xdebug]
+zend_extension=\"/usr/lib64/php/modules/xdebug.so\"
+xdebug.remote_enable = 1" >> /etc/php.ini
+
+echo "Restarting Apache after XDebug installed"
+/sbin/service httpd restart


### PR DESCRIPTION
Adds xdebug to your PHP installation.

Useful for code coverage reports when running test suites, for example.
