### PR TITLE
NEW Force environment files to have unix line endings

### DIFF
--- a/environment/.gitattributes
+++ b/environment/.gitattributes
@@ -1,0 +1,2 @@
+# all these files should have unix line endings
+* text eol=lf


### PR DESCRIPTION
Currently git checks the evnironment files (scripts and configs) out
with auto line-endings, that's not so nice when those scripts are meant
to be unix... Sorted that out
