### PR TITLE
Setting apache to run as vagrant

### DIFF
--- a/environment/config/httpd.conf
+++ b/environment/config/httpd.conf
@@ -239,8 +239,8 @@ Include conf.d/*.conf
 #  when the value of (unsigned)Group is above 60000; 
 #  don't use Group #-1 on these systems!
 #
-User apache
-Group apache
+User vagrant
+Group vagrant
 
 ### Section 2: 'Main' server configuration
 #

--- a/environment/scripts/apache.sh
+++ b/environment/scripts/apache.sh
@@ -44,6 +44,11 @@ else
 fi
 ln -s /vagrant/$WEBROOT /var/www/html
 
+if [ -d /var/lib/php/session ]
+then
+	chown -R vagrant: /var/lib/php/session
+fi
+
 echo "Starting httpd service"
 service httpd start
 


### PR DESCRIPTION
This fixes issues to do with httpd running on unix hosts. For some reason apache can't write to the assets folders and so on and one can't change the access permissions to those folders in the guest.

This gets around the problem by running apache as vagrant (the user that owns the mounted folder)

fixes #30
