### PR TITLE
Changing install order so PHP is done first

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,9 +27,9 @@ Vagrant.configure("2") do |config|
   #Install lamp and so on
   #In future will probably swap this out with something like Puppet
   config.vm.provision :shell, :path => "environment/scripts/iptables.sh"
-  config.vm.provision :shell, :path => "environment/scripts/apache.sh"
   config.vm.provision :shell, :path => "environment/scripts/php.sh"
   #config.vm.provision :shell, :path => "environment/scripts/php-55.sh"
+  config.vm.provision :shell, :path => "environment/scripts/apache.sh"
   config.vm.provision :shell, :path => "environment/scripts/mysql.sh"
   #config.vm.provision :shell, :path => "environment/scripts/mariadb-5.5.sh"
   #config.vm.provision :shell, :path => "environment/scripts/php-geoip.sh"

--- a/environment/scripts/apache.sh
+++ b/environment/scripts/apache.sh
@@ -45,7 +45,7 @@ fi
 ln -s /vagrant/$WEBROOT /var/www/html
 
 echo "Starting httpd service"
-service httpd start
+service httpd restart
 
 echo "Add port 80 to iptables"
 iptables -I INPUT 1 -p tcp --dport 80 -j ACCEPT


### PR DESCRIPTION
PHP has a dependency on apache when installed using yum. Therefore we can increase the provision speed by installing php first.
