### PR TITLE
Increasing PHP memory limit

### DIFF
--- a/environment/config/php.ini
+++ b/environment/config/php.ini
@@ -454,7 +454,7 @@ max_input_time = 60
 
 ; Maximum amount of memory a script may consume (128MB)
 ; http://www.php.net/manual/en/ini.core.php#ini.memory-limit
-memory_limit = 64M
+memory_limit = 256M
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;


### PR DESCRIPTION
To run the SS unit tests there is a need for a lot more memory than we apply at the moment.

Good to let it work out of the box IMO, than having to change it everytime
