### PR TITLE
Adding support for compressed DB files

### DIFF
--- a/environment/scripts/mysql.sh
+++ b/environment/scripts/mysql.sh
@@ -27,6 +27,26 @@ else
 	exit 1
 fi
 
+DEL_FILES=()
+#extract .sql.gz files - these need to be cleaned up afterwards!
+GZ_FILES=/vagrant/$DATABASE_FOLDER/*.sql.gz
+shopt -s nullglob
+for file in $GZ_FILES
+do
+	FILENAME=`basename $file .gz`
+	gunzip -c -v $file > /vagrant/$DATABASE_FOLDER/$FILENAME
+	DEL_FILES+=("/vagrant/$DATABASE_FOLDER/$FILENAME")
+done;
+
+BZ2_FILES=/vagrant/$DATABASE_FOLDER/*.sql.bz2
+shopt -s nullglob
+for file in $BZ2_FILES
+do
+	FILENAME=`basename $file .bz2`
+	bzip2 -dkc $file > /vagrant/$DATABASE_FOLDER/$FILENAME
+	DEL_FILES+=("/vagrant/$DATABASE_FOLDER/$FILENAME")
+done;
+
 DB_FILES=/vagrant/$DATABASE_FOLDER/*.sql
 shopt -s nullglob
 for file in $DB_FILES
@@ -38,6 +58,11 @@ do
 
 	echo "Importing database dump"
 	sed '/^CREATE DATABASE/d;/^USE/d' $file | mysql $DB_NAME -u root
+done;
+
+for file in $DEL_FILES
+do
+	rm -f $file
 done;
 
 echo "Databases imported"


### PR DESCRIPTION
Adding support for .gz and .bz2 compressed DB files.

DB files must be in the form:
DB_NAME.sql.gz|bz2
One database file per compressed file
