### PR TITLE
Add php-mcrypt to php extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ Edit the `Vagrantfile` to enable or disable install scripts as they are required
 |mariadb-5.5.sh       |Software |MariaDB            |5.5|MariaDB.org|Installs MariaDB, opens port 3306, imports dumps in /vagrant/database
 |php-geoip.sh         |Software |PHP GeoIP extension|-|EPEL|Installs PHP's GeoIP functions
 |php-phpunit.sh       |Software |PHP PHPUnit library|3.7.x|PEAR|Installs PEAR, then uses PEAR to install PHPUnit
-|php-xdebug.sh        |Software |PHP XDebug         |-|CentOS, PECL|Installs XDebug along with its automake, gcc, and php-devel 
+|php-xdebug.sh        |Software |PHP XDebug         |-|CentOS, PECL|Installs XDebug along with its automake, gcc, and php-devel
 |php-apc.sh           |Software |PHP APC            |-|CentOS, PECL|Installs APC. Only needed for PHP 5.3.x as 5.5 has it built-in.
+|php-mcrypt.sh        |Software |PHP Mcrypt extension|-|EPEL|Installs Mcrypt. Only needed for PHP 5.3.x as 5.5 has it built-in.
 |mongo.sh             |Software |MongoDB            |10gen|MongoDB.org|Installs the MongoDB NoSQL database
 |php-mongo.sh         |Software |PHP MongoDB|-|PEAR, PECL|Installs the PHP MongoDB extension
 |ntp.sh               |Config   |ntp|-|CentOS|Installs NTP which handles time management

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -38,6 +38,7 @@ Vagrant.configure("2") do |config|
   #config.vm.provision :shell, :path => "environment/scripts/php-pear-phpunit.sh"
   #config.vm.provision :shell, :path => "environment/scripts/php-xdebug.sh"
   #config.vm.provision :shell, :path => "environment/scripts/php-apc.sh"
+  #config.vm.provision :shell, :path => "environment/scripts/php-mcrypt.sh"
   #config.vm.provision :shell, :path => "environment/scripts/mongo.sh"
   #config.vm.provision :shell, :path => "environment/scripts/php-mongo.sh"
   #config.vm.provision :shell, :path => "environment/scripts/ntp.sh"

--- a/environment/scripts/php-mcrypt.sh
+++ b/environment/scripts/php-mcrypt.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# This is only required to install mcrypt in php versions < 5.4 on CentOS
+# Ensure you include in provisioning AFTER php.sh
+
+echo "Installing Mcrypt php extension"
+rpm -ivh http://www.mirrorservice.org/sites/dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+yum update
+yum install -y php-mcrypt
+
+echo "Restarting Apache"
+/sbin/service httpd restart
+
+echo "Mcrypt installed"


### PR DESCRIPTION
While not a server requirement for SilverStripe I found that projects using http://addons.silverstripe.org/add-ons/silverstripe/hybridsessions required this extension. Implementation is based on article at http://www.mojowill.com/geek/php-mcrypt-on-centos-6/

Closes #45 
