### PR TITLE
Make sake globally accessible

### DIFF
--- a/environment/scripts/silverstripe-tasks.sh
+++ b/environment/scripts/silverstripe-tasks.sh
@@ -21,6 +21,8 @@ if [ -f "framework/sake" ]
 then
 	chmod +x framework/sake
 	echo "sake is now executable"
+	framework/sake installsake
+	echo "sake in installed and global"
 fi
 
 echo "SilverStripe helper tasks complete"


### PR DESCRIPTION
Allows users to simply run "sake dev/somecommand" in the webroot.

Testing locally and correctly installs executable version of sake into /usr/bin
