### PR TITLE
Adding Gulp support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/bootstrap/compiled.php
+.env.*.php
+.env.php
+.vagrant
+*.sublime-*
+node_modules/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -45,6 +45,7 @@ Vagrant.configure("2") do |config|
   #config.vm.provision :shell, :path => "environment/scripts/node.sh"
   #config.vm.provision :shell, :path => "environment/scripts/grunt.sh"
   #config.vm.provision :shell, :path => "environment/scripts/grunt-watch.sh"
+  #config.vm.provision :shell, :path => "environment/scripts/gulp.sh"
   config.vm.provision :shell, :path => "environment/scripts/composer.sh"
   #config.vm.provision :shell, :path => "environment/scripts/libjpeg-jpegoptim.sh"
   #config.vm.provision :shell, :path => "environment/scripts/optipng.sh"

--- a/environment/scripts/gulp.sh
+++ b/environment/scripts/gulp.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "Installing Gulp by NPM"
+cd /vagrant
+npm install gulp --save-dev --no-bin-links


### PR DESCRIPTION
This adds Gulp to your Vagrant box. `--no-bin-links` [is needed](https://github.com/npm/npm/issues/5310#issuecomment-57121448) because otherwise VirtualBox's shared folders cause some weird issues.

Sup @dhensby 
