### PR TITLE
PHP versioning, little cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,32 +44,32 @@ Edit the `Vagrantfile` to enable or disable install scripts as they are required
 
 ## Included scripts and software
 
-|Script               |Purpose  |Software|Version|Repo|Description|
-|---------------------|---------|--------|-------|----|-----------|
-|iptables.sh          |Config   |-                  |-|-|Opens port 22 so you can access your vagrant box
-|apache.sh            |Software |Apache             |2.x|CentOS|Mounts the www _or_ public_html dir to webroot, installs Apache, opens ports 80 and 443
-|php-53.sh            |Software |PHP                |5.3.x|CentOS|Installs PHP 5.3, restarts Apache
-|php-55.sh            |Software |PHP                |5.5.x|Webtatic EL6|Installs PHP 5.5, restarts Apache
-|php-56.sh            |Software |PHP                |5.6.x|Webtatic EL6|Installs PHP 5.6, restarts Apache
-|mysql.sh             |Software |MySQL              |5.x|CentOS|Installs MySQL, opens port 3306, imports dumps in /vagrant/database
-|mariadb-5.5.sh       |Software |MariaDB            |5.5|MariaDB.org|Installs MariaDB, opens port 3306, imports dumps in /vagrant/database
-|php-geoip.sh         |Software |PHP GeoIP extension|-|EPEL|Installs PHP's GeoIP functions
-|php-phpunit.sh       |Software |PHP PHPUnit library|3.7.x|PEAR|Installs PEAR, then uses PEAR to install PHPUnit
-|php-xdebug.sh        |Software |PHP XDebug         |-|CentOS, PECL|Installs XDebug along with its automake, gcc, and php-devel
-|php-apc.sh           |Software |PHP APC            |-|CentOS, PECL|Installs APC. Only needed for PHP 5.3.x as 5.5 has it built-in.
-|php-mcrypt.sh        |Software |PHP Mcrypt extension|-|EPEL|Installs Mcrypt. Only needed for PHP 5.3.x as 5.5 has it built-in.
-|mongo.sh             |Software |MongoDB            |10gen|MongoDB.org|Installs the MongoDB NoSQL database
-|php-mongo.sh         |Software |PHP MongoDB|-|PEAR, PECL|Installs the PHP MongoDB extension
-|ntp.sh               |Config   |ntp|-|CentOS|Installs NTP which handles time management
-|node.sh              |Software |NodeJS|-|Fedora EPEL|Installs the NodeJS language and its package manager, NPM
-|grunt.sh             |Software |Grunt|-|NPM|Installs the NodeJS based task runner, grunt.
-|grunt-watch.sh       |Software |Grunt watch daemon|-|-|Sets up an automatic `grunt watch` task that will run on `vagrant up`
-|composer.sh          |Software |Composer|-|getcomposer.org|Installs PHP's composer package manager
-|sspak.sh         	  |Software |SSPak|-|Installs SSPak|Asset and database snapshot tool for SilverStripe ([link](//github.com/silverstripe/sspak))
-|libjpeg-jpegoptim.sh |Software |libjpeg; jpegoptim|-|CentOS; CentALT|Installs libjpeg and jpegoptim for use with compressing JPEG images
-|optipng.sh           |Software |optipng|-|CentOS|Installs optipng for use with compressing PNG images
-|sass.sh              |Software |Ruby, RubyGems, SASS|3.2.10|CentOS|Installs SASS 3.2.10, a handy CSS pre processor
-|bootstrap.sh         |Config   |-|-|-|Various bootstrap tasks and snag fixes
+|Script               |Name|Version|Repo|Description|
+|---------------------|--------|-------|----|-----------|
+|iptables.sh          |-       |-|-|Opens port 22 so you can access your vagrant box
+|apache.sh            |Apache             |2.x|CentOS|Mounts the www _or_ public_html dir to webroot, installs Apache, opens ports 80 and 443
+|php-53.sh            |PHP                |5.3.x|CentOS|Installs PHP 5.3, restarts Apache
+|php-55.sh            |PHP                |5.5.x|Webtatic EL6|Installs PHP 5.5, restarts Apache
+|php-56.sh            |PHP                |5.6.x|Webtatic EL6|Installs PHP 5.6, restarts Apache
+|mysql.sh             |MySQL              |5.x|CentOS|Installs MySQL, opens port 3306, imports dumps in /vagrant/database
+|mariadb-5.5.sh       |MariaDB            |5.5|MariaDB.org|Installs MariaDB, opens port 3306, imports dumps in /vagrant/database
+|php-geoip.sh         |PHP GeoIP extension|-|EPEL|Installs PHP's GeoIP functions
+|php-phpunit.sh       |PHP PHPUnit library|3.7.x|PEAR|Installs PEAR, then uses PEAR to install PHPUnit
+|php-xdebug.sh        |PHP XDebug         |-|CentOS, PECL|Installs XDebug along with its automake, gcc, and php-devel
+|php-apc.sh           |PHP APC            |-|CentOS, PECL|Installs APC. Only needed for PHP 5.3.x as 5.5 has it built-in.
+|php-mcrypt.sh        |PHP Mcrypt extension|-|EPEL|Installs Mcrypt. Only needed for PHP 5.3.x as 5.5 has it built-in.
+|mongo.sh             |MongoDB            |10gen|MongoDB.org|Installs the MongoDB NoSQL database
+|php-mongo.sh         |PHP MongoDB|-|PEAR, PECL|Installs the PHP MongoDB extension
+|ntp.sh               |ntp|-|CentOS|Installs NTP which handles time management
+|node.sh              |NodeJS|-|Fedora EPEL|Installs the NodeJS language and its package manager, NPM
+|grunt.sh             |Grunt|-|NPM|Installs the NodeJS based task runner, grunt.
+|grunt-watch.sh       |Grunt watch daemon|-|-|Sets up an automatic `grunt watch` task that will run on `vagrant up`
+|composer.sh          |Composer|-|getcomposer.org|Installs PHP's composer package manager
+|sspak.sh         	  |SSPak|-|Installs SSPak|Asset and database snapshot tool for SilverStripe ([link](//github.com/silverstripe/sspak))
+|libjpeg-jpegoptim.sh |libjpeg; jpegoptim|-|CentOS; CentALT|Installs libjpeg and jpegoptim for use with compressing JPEG images
+|optipng.sh           |optipng|-|CentOS|Installs optipng for use with compressing PNG images
+|sass.sh              |Ruby, RubyGems, SASS|3.2.10|CentOS|Installs SASS 3.2.10, a handy CSS pre processor
+|bootstrap.sh         |-|-|-|Various bootstrap tasks and snag fixes
 
 ## Environments
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Edit the `Vagrantfile` to enable or disable install scripts as they are required
 |grunt.sh             |Software |Grunt|-|NPM|Installs the NodeJS based task runner, grunt.
 |grunt-watch.sh       |Software |Grunt watch daemon|-|-|Sets up an automatic `grunt watch` task that will run on `vagrant up`
 |composer.sh          |Software |Composer|-|getcomposer.org|Installs PHP's composer package manager
-|sspak.sh         	  |Software |SSPak|-|https://github.com/silverstripe/sspak|Asset and database snapshot tool for SilverStripe
+|sspak.sh         	  |Software |SSPak|-|Installs SSPak|Asset and database snapshot tool for SilverStripe ([link](//github.com/silverstripe/sspak))
 |libjpeg-jpegoptim.sh |Software |libjpeg; jpegoptim|-|CentOS; CentALT|Installs libjpeg and jpegoptim for use with compressing JPEG images
 |optipng.sh           |Software |optipng|-|CentOS|Installs optipng for use with compressing PNG images
 |sass.sh              |Software |Ruby, RubyGems, SASS|3.2.10|CentOS|Installs SASS 3.2.10, a handy CSS pre processor

--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ Edit the `Vagrantfile` to enable or disable install scripts as they are required
 |---------------------|---------|--------|-------|----|-----------|
 |iptables.sh          |Config   |-                  |-|-|Opens port 22 so you can access your vagrant box
 |apache.sh            |Software |Apache             |2.x|CentOS|Mounts the www _or_ public_html dir to webroot, installs Apache, opens ports 80 and 443
-|php.sh               |Software |PHP                |5.3.x|CentOS|Installs PHP 5.3, restarts Apache
+|php-53.sh            |Software |PHP                |5.3.x|CentOS|Installs PHP 5.3, restarts Apache
 |php-55.sh            |Software |PHP                |5.5.x|Webtatic EL6|Installs PHP 5.5, restarts Apache
+|php-56.sh            |Software |PHP                |5.6.x|Webtatic EL6|Installs PHP 5.6, restarts Apache
 |mysql.sh             |Software |MySQL              |5.x|CentOS|Installs MySQL, opens port 3306, imports dumps in /vagrant/database
 |mariadb-5.5.sh       |Software |MariaDB            |5.5|MariaDB.org|Installs MariaDB, opens port 3306, imports dumps in /vagrant/database
 |php-geoip.sh         |Software |PHP GeoIP extension|-|EPEL|Installs PHP's GeoIP functions

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,8 +27,9 @@ Vagrant.configure("2") do |config|
   #Install lamp and so on
   #In future will probably swap this out with something like Puppet
   config.vm.provision :shell, :path => "environment/scripts/iptables.sh"
-  config.vm.provision :shell, :path => "environment/scripts/php.sh"
+  config.vm.provision :shell, :path => "environment/scripts/php-53.sh"
   #config.vm.provision :shell, :path => "environment/scripts/php-55.sh"
+  #config.vm.provision :shell, :path => "environment/scripts/php-56.sh"
   config.vm.provision :shell, :path => "environment/scripts/apache.sh"
   #config.vm.provision :shell, :path => "environment/scripts/custom-yum-remi-repo.sh" # needed for xsendfile
   #config.vm.provision :shell, :path => "environment/scripts/apache-modxsendfile.sh"

--- a/environment/scripts/php-53.sh
+++ b/environment/scripts/php-53.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "Installing PHP and common modules"
+echo "Installing PHP 5.3 and common modules"
 yum install -y php php-common php-pdo php-mysql php-session php-dom php-gd php-fileinfo php-hash php-iconv php-mbstring php-simplexml php-tokenizer php-xml php-tidy
 
 echo "Copying php.ini"

--- a/environment/scripts/php-55.sh
+++ b/environment/scripts/php-55.sh
@@ -3,7 +3,7 @@
 echo "Installing PHP 5.5"
 rpm -Uvh http://mirror.webtatic.com/yum/el6/latest.rpm
 
-yum install -y php55w php55w-common php55w-pdo php55w-mysqlnd php55w-session php55w-dom php55w-gd php55w-fileinfo php55w-hash php55w-iconv php55w-mbstring php55w-simplexml php55w-tokenizer php55w-xml php55w-tidy
+yum install -y php55w php55w-common php55w-pdo php55w-mysqlnd php55w-session php55w-dom php55w-gd php55w-fileinfo php55w-hash php55w-iconv php55w-mbstring php55w-mcrypt php55w-simplexml php55w-tokenizer php55w-xml php55w-tidy
 
 echo "Copying php.ini"
 cp -f /vagrant/environment/config/php.ini /etc/php.ini

--- a/environment/scripts/php-56.sh
+++ b/environment/scripts/php-56.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "Installing PHP 5.6"
+rpm -Uvh http://mirror.webtatic.com/yum/el6/latest.rpm
+
+yum install -y php56w php56w-common php56w-pdo php56w-mysqlnd php56w-session php56w-dom php56w-gd php56w-fileinfo php56w-hash php56w-iconv php56w-mbstring php56w-mcrypt php56w-simplexml php56w-tokenizer php56w-xml php56w-tidy
+
+echo "Copying php.ini"
+cp -f /vagrant/environment/config/php.ini /etc/php.ini
+
+echo "Restarting Apache"
+/sbin/service httpd restart
+
+echo "PHP installed"

--- a/environment/scripts/php-mcrypt.sh
+++ b/environment/scripts/php-mcrypt.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # This is only required to install mcrypt in php versions < 5.4 on CentOS
+# Mcrypt is a common dependency for 5.5+ apps, so it is installed by default with those scripts
 # Ensure you include in provisioning AFTER php.sh
 
 echo "Installing Mcrypt php extension"


### PR DESCRIPTION
* Markdown has been changed slightly so there's no horizontal scrollbar in the README viewer.
* The "Purpose" column on the README was a bit much and didn't have much use, so it's been removed
* The default version of PHP has been shifted to PHP 5.6, with 5.5 and 5.3 scripts provided. All `php-x.sh` scripts have been suffixed with their versions.
* Mcrypt is now installed by default for 5.5 >=