### PR TITLE
FIX Add php-tidy for unit tests

### DIFF
--- a/scripts/php-54.sh
+++ b/scripts/php-54.sh
@@ -3,10 +3,15 @@
 PHP_NAME="php"
 
 # declare the php modules we want
-MODULES=(common mysql gd mbstring xml)
+MODULES=(common mysql gd mbstring xml tidy)
 
 echo "Installing PHP and common modules"
 yum install -y $PHP_NAME ${MODULES[@]/#/$PHP_NAME-}
+
+#install EPEL repo
+/vagrant/scripts/epel.sh
+
+yum install -y php-tidy --enablerepo=epel
 
 # use the dev php.ini file
 cp -f /usr/share/doc/$PHP_NAME-*/php.ini-development /etc/php.ini

--- a/scripts/php-55.sh
+++ b/scripts/php-55.sh
@@ -3,7 +3,7 @@
 PHP_NAME="php55w"
 
 # declare the php modules we want
-MODULES=(common mysql gd mbstring xml)
+MODULES=(common mysql gd mbstring xml tidy)
 
 /vagrant/scripts/epel.sh
 

--- a/scripts/php-56.sh
+++ b/scripts/php-56.sh
@@ -3,7 +3,7 @@
 PHP_NAME="php55w"
 
 # declare the php modules we want
-MODULES=(common mysql gd mbstring xml)
+MODULES=(common mysql gd mbstring xml tidy)
 
 /vagrant/scripts/epel.sh
 


### PR DESCRIPTION
Unit tests need php-tidy - this installs it as required

php-tidy doesn't appear to be in the CentOS repos so we have to install through EPEL