### PR TITLE
Fixing bugs with xhprof

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure("2") do |config|
   #config.vm.network :forwarded_port, guest: 443, host: 443, auto_correct: true
   config.vm.network :forwarded_port, guest: 3306, host: 3306, auto_correct: true
   config.vm.network :forwarded_port, guest: 1080, host: 1080, auto_correct: true
-  #config.vm.network :forwarded_port, guest: 1090, host: 1090, auto_correct: true
+  config.vm.network :forwarded_port, guest: 1090, host: 1090, auto_correct: true
 
   #Uncomment this if you want bridged network functionality
   #config.vm.network :public_network
@@ -23,10 +23,10 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, :path => "scripts/php-54.sh"
   #config.vm.provision :shell, :path => "scripts/php-55.sh"
   #config.vm.provision :shell, :path => "scripts/php-56.sh"
-  #config.vm.provision :shell, :path => "scripts/php-xhprof.sh"
   config.vm.provision :shell, :path => "scripts/composer.sh"
   config.vm.provision :shell, :path => "scripts/apache.sh"
   config.vm.provision :shell, :path => "scripts/mariadb.sh"
+  #config.vm.provision :shell, :path => "scripts/php-xhprof.sh"
   #config.vm.provision :shell, :path => "scripts/php-mcrypt.sh"
   #config.vm.provision :shell, :path => "scripts/xdebug.sh"
   #config.vm.provision :shell, :path => "scripts/ntp.sh"

--- a/scripts/php-xhprof.sh
+++ b/scripts/php-xhprof.sh
@@ -24,6 +24,7 @@ touch /tmpxh_dot.err
 chmod 0777 /tmpxh_dot.err
 
 # sym link xhprof repo - needed to access _ss_env file
+rm -rf /var/www/xhprof
 ln -s /vagrant/xhprof/ /var/www/xhprof
 
 # add a port listener to apache for xhprof access


### PR DESCRIPTION
This fixes some issues with the xhprof installer.

Current known issues:
- .htaccess manipulated repeatedly and has php_flag appended on subsequent provisions
- Needs testing with php 5.5+

cc @Firesphere 

Also, note the main issue with this install was the order of inclusion. It was trying to install before git and the DB were provisioned.
