### PR TITLE
Allow root bower use out of the box

### DIFF
--- a/scripts/bower.sh
+++ b/scripts/bower.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 
+# Deps
+/vagrant/scripts/node.sh
+
 # Install bower
 echo "Installing bower"
 npm install -g bower
+
+echo '{ "allow_root": true }' > /root/.bowerrc
 
 echo "Bower installed"
 


### PR DESCRIPTION
Most of our usage on the box is as root user.

This explicitly allows the root user to use bower without repeatedly using the `--allow-root` flag