### PR TITLE
Adding fix to allow `yum update` to work

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -8,4 +8,7 @@ if [ ! "$(grep single-request-reopen /etc/resolv.conf)" ];
 	then echo 'options single-request-reopen' >> /etc/resolv.conf && systemctl restart network;
 fi
 
+yum install -y kernel-devel-$(uname -r) kernel-headers-$(uname -r)
+/etc/init.d/vboxadd setup
+
 echo "Bootstrap complete"


### PR DESCRIPTION
When running `yum update` the mounting of shared folders breaks.

This fixes the problem. fixes #81