### PR TITLE
Separating webroot mounting logic from apache installer

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,6 +20,7 @@ Vagrant.configure("2") do |config|
 
   #Install lamp and so on
   #In future will probably swap this out with something like Puppet
+  config.vm.provision :shell, :path => "scripts/mount-webroot.sh"
   config.vm.provision :shell, :path => "scripts/php-54.sh"
   #config.vm.provision :shell, :path => "scripts/php-55.sh"
   #config.vm.provision :shell, :path => "scripts/php-56.sh"

--- a/scripts/apache.sh
+++ b/scripts/apache.sh
@@ -13,41 +13,11 @@
 # expires
 # include
 
-#List of valid webroots in priority order
-WEBROOTS=('/vagrant/project/public/' '/vagrant/www/' '/vagrant/public_html/' '/vagrant/webroot/' '/vagrant/public/')
-
-
 echo "Installing Apache"
 yum install -y httpd
 
 echo "Adding Apache service to autostart"
 systemctl enable httpd.service
-
-echo "Mounting webroot"
-# pick the webroot
-for i in ${WEBROOTS[@]}
-do
-	if [ -d $i ]
-	then
-		echo "Found Webroot"
-		WEBROOT=$i
-		break
-	fi
-done
-
-if [ -z "$WEBROOT" ]
-then
-	echo "No webroot, installing SS"
-	WEBROOT="/vagrant/www"
-
-	/vagrant/scripts/install-silverstripe.sh -d ${WEBROOT}
-fi
-
-if [ -d $WEBROOT ]
-then
-	rm -rf /var/www/html
-	ln -s $WEBROOT /var/www/html
-fi
 
 # replace the user/group of apache
 sed -i 's/User apache/User vagrant/i' /etc/httpd/conf/httpd.conf

--- a/scripts/grunt.sh
+++ b/scripts/grunt.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo "Installing Grunt & Grunt CLI by NPM"
-npm install -y -g grunt-cli
+npm install -g grunt-cli
 
 if [ -r "/var/www/html/package.json" ]
 then

--- a/scripts/install-silverstripe.sh
+++ b/scripts/install-silverstripe.sh
@@ -1,26 +1,30 @@
 #!/usr/bin/env bash
 
 INSTALL_DIR=/vagrant/www/
-
+INSTALL_DESTINATION=/var/www/html
 INSTALL_VERSION=''
 
 INSTALLER_NAME='silverstripe/installer'
 
 function usage() {
-	echo -e "Syntax `basename $0` [-h] [-v version] [-d directory] [-i installer]
+	echo -e "Syntax `basename $0` [-h] [-v version] [-d directory] [-i installer] [-w webroot]
 	-h Show this help
 	-v Set the version constraint for the isntaller
 	-d Set the directory to install into
-	-i Set the installer\n"
+	-i Set the installer\n
+	-w Set the webroot to symlink"
 }
 
 function install() {
-	composer create-project ${INSTALLER_NAME} ${INSTALL_DIR} ${INSTALL_VERSION}
-	exit $?
+	if [[ ! -d ${INSTALL_DIR} ]] || [[ ! $(ls -A ${INSTALL_DIR}) ]]; then
+		composer create-project ${INSTALLER_NAME} ${INSTALL_DIR} ${INSTALL_VERSION}
+	else
+		echo "WARNING: Install directory is not empty; not installing"
+	fi
+	return $?
 }
 
-#set up the username and password
-while getopts "hv:d:i:" OPTION; do
+while getopts "hv:d:i:w" OPTION; do
 	case ${OPTION} in
 		v ) INSTALL_VERSION="$OPTARG"
 			;;
@@ -28,9 +32,12 @@ while getopts "hv:d:i:" OPTION; do
 			;;
 		i ) INSTALLER_NAME="$OPTARG"
 			;;
+		w ) INSTALL_DESTINATION="$OPTARG"
+			;;
 		h ) usage
 			exit 0
 	esac
 done
 
 install
+/vagrant/scripts/mount-webroot.sh -w "${INSTALL_DIR}"

--- a/scripts/install-silverstripe.sh
+++ b/scripts/install-silverstripe.sh
@@ -1,18 +1,17 @@
 #!/usr/bin/env bash
 
-INSTALL_DIR=/vagrant/www/
-INSTALL_DESTINATION=/var/www/html
-INSTALL_VERSION=''
-
-INSTALLER_NAME='silverstripe/installer'
+INSTALL_DIR=/vagrant/www/ # The directory to install silverstripe into
+INSTALL_DESTINATION=/var/www/html # The directory to symlink the install dir to. Pass an empty -w flag to avoid symlink
+INSTALL_VERSION='' # The version constraint we want, by default it will be latest stable
+INSTALLER_NAME='silverstripe/installer' # The composer installer name, this could be changed to a custom one if needed
 
 function usage() {
 	echo -e "Syntax `basename $0` [-h] [-v version] [-d directory] [-i installer] [-w webroot]
 	-h Show this help
-	-v Set the version constraint for the isntaller
+	-v Set the version constraint for the installer
 	-d Set the directory to install into
-	-i Set the installer\n
-	-w Set the webroot to symlink"
+	-i Set the installer
+	-w Set the webroot to symlink\n"
 }
 
 function install() {

--- a/scripts/mount-webroot.sh
+++ b/scripts/mount-webroot.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+#List of valid webroots in priority order
+WEBROOTS=('/vagrant/project/public/' '/vagrant/www/' '/vagrant/public_html/' '/vagrant/webroot/' '/vagrant/public/')
+DESTINATION=/var/www/html
+WEBROOT=''
+
+function run() {
+	echo "Mounting webroot"
+	# pick the webroot
+	if [ -z $WEBROOT ]; then
+		for i in ${WEBROOTS[@]}
+		do
+			if [ -d $i ]
+			then
+				echo "Found Webroot"
+				WEBROOT=$i
+				break
+			fi
+		done
+	fi
+
+	if [ -d $WEBROOT ]
+	then
+		rm -rf $DESTINATION
+		ln -s $WEBROOT $DESTINATION
+	else
+		echo "WARNING: Couldn't find webroot"
+	fi
+}
+
+function usage() {
+	echo -e "Coming soon"
+}
+
+while getopts "hd:w:" OPTION; do
+	case ${OPTION} in
+		d ) DESTINATION="$OPTARG"
+			;;
+		w ) WEBROOT="$OPTARG"
+			;;
+		h ) usage
+			exit 0
+	esac
+done
+
+run


### PR DESCRIPTION
With the introduction of the new SilverStripe installer script, a problem has occurred where the webroot wasn't always mounted into `/var/www/html` as the apache installer also takes responsibility for this, but was running before the SS installer had (due to PHP / composer deps for SS install)

This change pulls the webroot mounting into it's own script.

The first thing the provisioner will do is mount the webroot if it exists, php and apache can then install, then bring in composer.

After that the SS installer can run and it calls the `mount-webroot` script, thus resolving this problem.