### PR TITLE
HHVM provisioner

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,6 +24,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, :path => "scripts/php-54.sh"
   #config.vm.provision :shell, :path => "scripts/php-55.sh"
   #config.vm.provision :shell, :path => "scripts/php-56.sh"
+  #config.vm.provision :shell, :path => "scripts/php-hhvm.sh"
   #config.vm.provision :shell, :path => "scripts/php-xhprof.sh"
   config.vm.provision :shell, :path => "scripts/composer.sh"
   #config.vm.provision :shell, :path => "scripts/install-silverstripe.sh", :args => "-v 3.x-dev"

--- a/scripts/php-hhvm-nightly.sh
+++ b/scripts/php-hhvm-nightly.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+
+# Building HHVM from sauce
+# see https://github.com/facebook/hhvm/wiki/Building-and-installing-hhvm-on-CentOS-7.x
+echo "Building HHVM from source"
+echo "Installing dependencies"
+
+/vagrant/scripts/epel.sh
+/vagrant/scripts/mariadb.sh
+
+yum install -y cpp gcc-c++ cmake git psmisc {binutils,boost,jemalloc}-devel \
+{ImageMagick,sqlite,tbb,bzip2,openldap,readline,elfutils-libelf,gmp,lz4,pcre}-devel \
+lib{xslt,event,yaml,vpx,png,zip,icu,mcrypt,memcached,cap,dwarf}-devel \
+{unixODBC,expat,mariadb}-devel lib{edit,curl,xml2,xslt}-devel \
+glog-devel oniguruma-devel ocaml gperf enca libjpeg-turbo-devel openssl-devel \
+make mariadb-devel --enablerepo=epel
+
+service mariadb restart
+
+echo "Dependencies installed"
+
+echo "Cloning HHVM"
+cd /tmp
+git clone https://github.com/facebook/hhvm -b master  hhvm  --recursive
+cd hhvm
+
+echo "HHVM cloned"
+
+echo "Compliling HHVM, this will take a while"
+# ./configure # That is a cmake wrapper, ignore it.
+cmake .
+make -j$(($(nproc)+1)) # make with CORE_COUNT+1 threads, that would be fast. You may run out of RAM
+
+echo "HHVM compiled"
+# Test..
+./hphp/hhvm/hhvm --version
+echo "Installing HHVM"
+# Install it..
+make install
+
+echo "[Unit]
+Description=HHVM HipHop Virtual Machine (FCGI)
+
+[Service]
+ExecStartPre=-/usr/bin/mkdir -p /var/run/hhvm
+ExecStartPre=-/usr/bin/chown nobody /var/run/hhvm
+ExecStart=/usr/local/bin/hhvm --config /etc/hhvm/server.ini --user nobody --mode daemon -vServer.Type=fastcgi -vServer.Port=9000
+
+[Install]
+WantedBy=multi-user.target" >> /usr/lib/systemd/system/hhvm.service
+
+echo "Running HHVM"
+
+systemctl enable hhvm
+systemctl start hhvm
+systemctl status hhvm
+
+echo "HHVM installed"

--- a/scripts/php-hhvm.sh
+++ b/scripts/php-hhvm.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+echo "Installing HHVM"
+
+echo "Installing dependencies"
+/vagrant/scripts/epel.sh
+
+wget https://copr.fedoraproject.org/coprs/no1youknowz/hhvm-repo/repo/epel-7/no1youknowz-hhvm-repo-epel-7.repo -O /etc/yum.repos.d/no1youknowz-hhvm-repo-epel-7.repo
+
+sed -i 's/enabled=1/enabled=0/g' /etc/yum.repos.d/no1youknowz-hhvm-repo-epel-7.repo
+
+yum install -y --enablerepo=no1youknowz-hhvm-repo --enablerepo=epel hhvm
+
+echo "Installation complete"


### PR DESCRIPTION
Adding HHVM  installers.

`php-hhvm.sh` "works" but composer doesn't install with it (as there's no `php` executable) and we need to enable fast_cgi for apache.

This makes it a PITA and almost like we'll need a whole set of HHVM provisioners, but that doesn't seem right. Perhaps I need to install php side-by-side?

closes #56 
