### PR TITLE
Updating node installer

### DIFF
--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -2,8 +2,11 @@
 
 echo "Installing NodeJS (CentOS method)"
 
-#install EPEL repo
-/vagrant/scripts/epel.sh
-
 echo "Installing NodeJS + NPM with EPEL"
-yum install -y npm --enablerepo=epel
+
+curl --silent --location https://rpm.nodesource.com/setup_4.x | bash -
+
+yum install -y nodejs
+
+#turn off bin links by default
+npm config set bin-links false


### PR DESCRIPTION
Using instructions from https://nodejs.org/en/download/package-manager/#enterprise-linux-and-fedora

The epel repo only seems to install ^0.10

This also turns off bin-links too (which is useful for windows hosts with shared file systems), though has some side-effects for global installs that now need to use `--bin-links` to get the CLI tools working "properly"