### PR TITLE
FIX PHP-mcrypt installer works with various version of PHP

### DIFF
--- a/scripts/php-mcrypt.sh
+++ b/scripts/php-mcrypt.sh
@@ -3,14 +3,27 @@
 # Mcrypt is a common dependency for 5.5+ apps, so it is installed by default with those scripts
 # Ensure you include in provisioning AFTER php.sh
 
+PACKAGE_NAME='php-'
+
 echo "Installing Mcrypt php extension"
 
 #install EPEL repo
 /vagrant/scripts/epel.sh
 
-yum install -y php-mcrypt --enablerepo=epel
+if `php -v | grep -Eq 'PHP 5.5'`; then
+	PACKAGE_NAME='php55w'
+elif `php -v | grep -Eq 'PHP 5.6'`; then
+	PACKAGE_NAME='php56w'
+fi
+
+yum install -y "${PACKAGE_NAME}-mcrypt" --enablerepo=epel --enablerepo=webtatic
 
 echo "Restarting Apache"
 systemctl restart httpd.service
 
-echo "Mcrypt installed"
+if `php -m | grep -q 'mcrypt'`; then
+	echo "mcrypt installed"
+else
+	echo "Failed to install mcrypt PHP extension successfully"
+	exit 1
+fi


### PR DESCRIPTION
Previously the mcrypt installer would only work if php 5.4 was installed.

Now it works with our supported versions (5.4, 5.5, 5.6)