### PR TITLE
FIX Make sure npm global installs use bin-links

### DIFF
--- a/scripts/bower.sh
+++ b/scripts/bower.sh
@@ -5,7 +5,7 @@
 
 # Install bower
 echo "Installing bower"
-npm install -g bower
+npm install -g --bin-links bower
 
 echo '{ "allow_root": true }' > /root/.bowerrc
 

--- a/scripts/grunt.sh
+++ b/scripts/grunt.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo "Installing Grunt & Grunt CLI by NPM"
-npm install -g grunt-cli
+npm install -g --bin-links grunt-cli
 
 if [ -r "/var/www/html/package.json" ]
 then

--- a/scripts/gulp.sh
+++ b/scripts/gulp.sh
@@ -2,4 +2,4 @@
 
 echo "Installing Gulp"
 
-npm install --global gulp-cli --bin-links
+npm install --global --bin-links gulp-cli

--- a/scripts/less.sh
+++ b/scripts/less.sh
@@ -4,6 +4,6 @@ echo "Installing LESS"
 
 /vagrant/scripts/node.sh
 
-npm install -g less
+npm install -g --bin-links less
 
 echo "Less installed `less -v`"


### PR DESCRIPTION
Turning off `bin-links` globally means global installs don't get symlinked to the users path.

All global installs need symlinks, this PR makes sure that happens