### PR TITLE
Stop Composer super user warnings

### DIFF
--- a/scripts/composer.sh
+++ b/scripts/composer.sh
@@ -20,6 +20,9 @@ cat >/etc/profile.d/composer-bin-root.sh <<EOF
 
 pathmunge /home/vagrant/.composer/vendor/bin after
 pathmunge /root/.composer/vendor/bin after
+
+export COMPOSER_ALLOW_SUPERUSER=1
+
 EOF
 
 echo "Composer installed"


### PR DESCRIPTION
More often than not composer is run in root context on the vagrant machine. this is safe enough to do as it's sandboxed.