### PR TITLE
Skip php-mcrypt install on php7

### DIFF
--- a/scripts/php-mcrypt.sh
+++ b/scripts/php-mcrypt.sh
@@ -14,6 +14,9 @@ if `php -v | grep -Eq 'PHP 5.5'`; then
 	PACKAGE_NAME='php55w'
 elif `php -v | grep -Eq 'PHP 5.6'`; then
 	PACKAGE_NAME='php56w'
+elif `php -v | grep -Eq 'PHP 7.'`; then
+        echo "Skipping Mcrypt installation on PHP 7"
+        exit 0
 fi
 
 yum install -y "${PACKAGE_NAME}-mcrypt" --enablerepo=epel --enablerepo=webtatic


### PR DESCRIPTION
Mcrypt is deprecated in php-7 so this stops the script trying to install it on PHP 7 based systems.