### PR TITLE
Add root .env for better SS 4 support

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,15 @@
+# For a complete list of core environment variables see
+# https://docs.silverstripe.org/en/4/getting_started/environment_management/#core-environment-variables
+
+# DB credentials
+SS_DATABASE_SERVER="127.0.0.1"
+SS_DATABASE_CLASS="MySQLPDODatabase"
+SS_DATABASE_TIMEZONE="+00:00"
+SS_DATABASE_USERNAME="root"
+SS_DATABASE_PASSWORD=""
+SS_DATABASE_NAME="vagrant"
+
+SS_ENVIRONMENT_TYPE="dev"
+
+SS_DEFAULT_ADMIN_USERNAME="admin"
+SS_DEFAULT_ADMIN_PASSWORD="password"


### PR DESCRIPTION
you can put the `.env` a dir above the webroot if you want, so we might as well support this out of the box like we do for SS 3