### PR TITLE
Use bento/centos-7 box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ Vagrant.configure("2") do |config|
 
   #---Box config---
 
-  config.vm.box = "bento/centos-7.3"
+  config.vm.box = "bento/centos-7"
 
   config.vm.provider 'virtualbox' do |v|
     v.linked_clone = true if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0') 


### PR DESCRIPTION
Instead of always incrementing the minor version of centos when there's a release, this will allow us to just hook onto the latest 7 release.