### PR TITLE
Allow php7.2 installs

### DIFF
--- a/scripts/php.sh
+++ b/scripts/php.sh
@@ -29,6 +29,11 @@ while getopts "hqv:t:m:e:" OPTION; do
 				PHP_MODULES+=('opcache')
 				EXTRA_PACKAGES+=('mod_php71w')
 				USE_EPEL=true
+			elif [ "${OPTARG}" == "7.2" ] || [ "${OPTARG}" == "7" ]; then
+				VERSION="php72w"
+				PHP_MODULES+=('opcache')
+				EXTRA_PACKAGES+=('mod_php72w')
+				USE_EPEL=true
 			else
 				${QUIET} || >&2 echo "Unsupported PHP version '${OPTARG}'"
 				exit 1


### PR DESCRIPTION
- Allow php 7.2 installs (now that it's supported in webtatic)
- Allow installing with a generic "7" argument to get latest PHP 7 install (eg: `./scripts/php -v 7`)