### PR TITLE
Be more friendly to SS4 (and 4.1, which has a `public` web dir

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,10 +47,10 @@ Vagrant.configure("2") do |config|
   #Install lamp and so on
   #In future will probably swap this out with something like Puppet
   config.vm.provision :shell, :path => "scripts/mount-webroot.sh"
-  config.vm.provision :shell, :path => "scripts/php.sh", :args => "-v 5.6 -m 256 -t UTC"
-  config.vm.provision :shell, :path => "scripts/php-mcrypt.sh"
+  config.vm.provision :shell, :path => "scripts/php.sh", :args => "-v 7 -m 256 -t UTC"
+  #config.vm.provision :shell, :path => "scripts/php-mcrypt.sh"
   config.vm.provision :shell, :path => "scripts/composer.sh"
-  #config.vm.provision :shell, :path => "scripts/install-silverstripe.sh", :args => "-v 3.x-dev"
+  #config.vm.provision :shell, :path => "scripts/install-silverstripe.sh", :args => "-v 4.x-dev"
   config.vm.provision :shell, :path => "scripts/apache.sh"
   config.vm.provision :shell, :path => "scripts/mariadb.sh"
   #config.vm.provision :shell, :path => "scripts/mysql-57.sh"

--- a/scripts/install-silverstripe.sh
+++ b/scripts/install-silverstripe.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-INSTALL_DIR=/vagrant/www/ # The directory to install silverstripe into
+INSTALL_DIR=/vagrant/project # The directory to install silverstripe into
 INSTALL_DESTINATION=/var/www/html # The directory to symlink the install dir to. Pass an empty -w flag to avoid symlink
 INSTALL_VERSION='' # The version constraint we want, by default it will be latest stable
 INSTALLER_NAME='silverstripe/installer' # The composer installer name, this could be changed to a custom one if needed


### PR DESCRIPTION
- Install PHP 7 by default
- Install SS 4.x-dev by default (when using install-silverstripe script)
- Install into `./project` dir so that `mount-webroot.sh` will mount the `public/` dir correctly