### PR TITLE
Add /vagrant/project as a valid webroot option

### DIFF
--- a/scripts/mount-webroot.sh
+++ b/scripts/mount-webroot.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #List of valid webroots in priority order
-WEBROOTS=('/vagrant/project/public/' '/vagrant/www/' '/vagrant/public_html/' '/vagrant/webroot/' '/vagrant/public/')
+WEBROOTS=('/vagrant/project/public/' '/vagrant/www/' '/vagrant/public_html/' '/vagrant/webroot/' '/vagrant/public/' '/vagrant/project')
 DESTINATION='/var/www/html'
 WEBROOT=''
 


### PR DESCRIPTION
Default installs now go into `/vagrant/project` (even for SS3) so we need to make sure that's a valid webroot option when mounting