### PR TITLE
Define missing Vagrant min version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 Vagrant Skeleton
 ======================
 
-This is the Vagrant skeleton that we use at [Better Brief](http://betterbrief.co.uk). It's meant to form a "as close as possible" base to our live servers to keep fragmentation of environments to a minimum. There is obviously the advantage of easily portable development environments!
+A bare bones repository to form a "as close as possible" base to a sensibly-configured live server to keep fragmentation of environments to a minimum. There is obviously the advantage of easily portable development environments!
+
+This is a Vagrant skeleton that we used at Better Brief. It still gets used regularly so it's still somewhat regularly maintained.
 
 ## Guest OS
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,10 @@
 
 Vagrant.configure("2") do |config|
 
+  #---Minimum version for the bento/centos-7 box---
+
+  Vagrant.require_version ">= 2.1.0"
+
   #---Box config---
 
   config.vm.box = "bento/centos-7"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
   config.vm.box = "bento/centos-7"
 
   config.vm.provider 'virtualbox' do |v|
-    v.linked_clone = true if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0') 
+    v.linked_clone = true
   end
 
   #---Cachier plugin---


### PR DESCRIPTION
~~The 7 box is now discontinued.~~

https://app.vagrantup.com/chef/boxes/centos-7.0
https://app.vagrantup.com/bento/boxes/centos-7.0

Vagrant 1.9 doesn't play nice with the new Bento boxes