### PR TITLE
FIX Min vagrant version of 2.0

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ Vagrant.configure("2") do |config|
 
   #---Minimum version for the bento/centos-7 box---
 
-  Vagrant.require_version ">= 2.1.0"
+  Vagrant.require_version ">= 2.0.0"
 
   #---Box config---
 


### PR DESCRIPTION
I'm running vagrant 2.0 on one of my machines and it works fine, so we should loosen this constraint