### PR TITLE
Define composer bin dir from config

### DIFF
--- a/scripts/composer.sh
+++ b/scripts/composer.sh
@@ -18,8 +18,10 @@ echo "Adding composer's vendor directory to system PATH"
 cat >/etc/profile.d/composer-bin-root.sh <<EOF
 #!/usr/bin/env bash
 
-pathmunge /home/vagrant/.composer/vendor/bin after
-pathmunge /root/.composer/vendor/bin after
+COMPOSER_HOME=\$(composer config --global --no-interaction home)
+COMPOSER_BIN=\$(composer config --global --no-interaction bin-dir)
+
+pathmunge "\${COMPOSER_HOME}/\${COMPOSER_BIN}" after
 
 export COMPOSER_ALLOW_SUPERUSER=1
 


### PR DESCRIPTION
Set the composer bin dir from config settings, which is a better way of doing this and means we don't have to hard code bin dirs into our config :)

composer sometimes stores these in `~/.composer` or `~/.config/composer/` so it's best not to hard code :)